### PR TITLE
Bump for updated 0.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/kylebarron/arro3/archive/refs/tags/py-v{{ version }}.tar.gz
-  sha256: f74c6339a7c0072db0ee9b1cbe2b3724cd07489b8a3cb0df2b58b533bc972442
+  sha256: f2f929b1f69d2837b39aafc443611f7bb0e51f8e3f7aa1f1537d855602c5af1f
 
 build:
   script:
@@ -14,7 +14,7 @@ build:
     - {{ PYTHON }} -m pip install ./arro3-compute -vv  # [arro3_module == "arro3-compute"]
     - {{ PYTHON }} -m pip install ./arro3-io -vv  # [arro3_module == "arro3-io"]
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Due to some build issues I republished the 0.4.2 tag on the arro3 github repo, which meant that the SHA tag here is incorrect 🙃 . This should fix https://github.com/conda-forge/arro3-core-feedstock/pull/11#issuecomment-2414863955

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
